### PR TITLE
Fix: Update LLM Test Connection Models

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1073,7 +1073,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       let response;
 
       if (provider === 'gemini') {
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent`;
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent`;
         response = await axios.post(url, {
           contents: [{ parts: [{ text: "Hello" }] }]
         }, {
@@ -1081,21 +1081,21 @@ export function initializeIpcHandlers(appState: AppState): void {
         });
       } else if (provider === 'groq') {
         response = await axios.post('https://api.groq.com/openai/v1/chat/completions', {
-          model: "llama3-8b-8192",
+          model: "llama-3.3-70b-versatile",
           messages: [{ role: "user", content: "Hello" }]
         }, {
           headers: { Authorization: `Bearer ${apiKey}` }
         });
       } else if (provider === 'openai') {
         response = await axios.post('https://api.openai.com/v1/chat/completions', {
-          model: "gpt-3.5-turbo",
+          model: "gpt-5.2-chat-latest",
           messages: [{ role: "user", content: "Hello" }]
         }, {
           headers: { Authorization: `Bearer ${apiKey}` }
         });
       } else if (provider === 'claude') {
         response = await axios.post('https://api.anthropic.com/v1/messages', {
-          model: "claude-3-haiku-20240307",
+          model: "claude-sonnet-4-5",
           max_tokens: 10,
           messages: [{ role: "user", content: "Hello" }]
         }, {


### PR DESCRIPTION
## Problem
When testing API connections in Settings > AI Providers, users encountered errors like:
- `"models/gemini-1.5-flash is not found for API version v1beta"`
- Similar errors for Groq, OpenAI, and Claude

**Related Issue:** #53

## Root Cause
The `test-llm-connection` IPC handler in `electron/ipcHandlers.ts` was using outdated model names that didn't match the actual production models used in `LLMHelper.ts`. These models were incorrect since the initial implementation of the test connection feature.

## Changes
Updated model names in `electron/ipcHandlers.ts` to match production:

| Provider | Old Model | New Model |
|----------|-----------|-----------|
| **Gemini** | `gemini-1.5-flash` | `gemini-3-flash-preview` |
| **Groq** | `llama3-8b-8192` | `llama-3.3-70b-versatile` |
| **OpenAI** | `gpt-3.5-turbo` | `gpt-5.2-chat-latest` |
| **Claude** | `claude-3-haiku-20240307` | `claude-sonnet-4-5` |

## Testing
- ✅ Tested Gemini API key connection in Settings > AI Providers
- ✅ Tested Groq API key connection

## Files Changed
- `electron/ipcHandlers.ts` - Updated model names in `test-llm-connection` handler
