### PR TITLE
Fix: License Activation Crash (ThreadsafeFunction to AsyncTask Migration)

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -48,7 +48,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   safeHandle("license:activate", async (event, key: string) => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
-      return LicenseManager.getInstance().activateLicense(key);
+      return await LicenseManager.getInstance().activateLicense(key);
     } catch {
       return { success: false, error: 'Premium features not available in this build.' };
     }

--- a/native-module/index.d.ts
+++ b/native-module/index.d.ts
@@ -10,10 +10,10 @@
 export declare function getHardwareId(): string
 /**
  * Validates a Gumroad license key by calling the Gumroad Licenses API.
- * Returns "OK" on success, or an error message string on failure.
- * Calls are made in a background thread to prevent blocking the Node.js event loop.
+ * Returns a Promise that resolves to "OK" on success, or an error message string on failure.
+ * The HTTP call runs on a libuv worker thread to prevent blocking the Node.js event loop.
  */
-export declare function verifyGumroadKey(licenseKey: string, callback: (...args: any[]) => any): void
+export declare function verifyGumroadKey(licenseKey: string): Promise<unknown>
 export interface AudioDeviceInfo {
   id: string
   name: string

--- a/native-module/index.js
+++ b/native-module/index.js
@@ -313,11 +313,7 @@ if (!nativeBinding) {
 const { getHardwareId, verifyGumroadKey, SystemAudioCapture, MicrophoneCapture, getInputDevices, getOutputDevices } = nativeBinding
 
 module.exports.getHardwareId = getHardwareId
-module.exports.verifyGumroadKey = function(key) {
-  return new Promise((resolve) => {
-    verifyGumroadKey(key, resolve);
-  });
-};
+module.exports.verifyGumroadKey = verifyGumroadKey
 module.exports.SystemAudioCapture = SystemAudioCapture
 module.exports.MicrophoneCapture = MicrophoneCapture
 module.exports.getInputDevices = getInputDevices

--- a/native-module/src/license.rs
+++ b/native-module/src/license.rs
@@ -14,28 +14,24 @@ pub fn get_hardware_id() -> String {
     format!("{:x}", hasher.finalize())
 }
 
-use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode, ErrorStrategy};
 use napi::bindgen_prelude::*;
+use napi::Task;
 
-/// Validates a Gumroad license key by calling the Gumroad Licenses API.
-/// Returns "OK" on success, or an error message string on failure.
-/// Calls are made in a background thread to prevent blocking the Node.js event loop.
-#[napi]
-pub fn verify_gumroad_key(license_key: String, callback: JsFunction) -> napi::Result<()> {
-    let tsfn: ThreadsafeFunction<String, ErrorStrategy::Fatal> = callback
-        .create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+/// Background task that verifies a Gumroad license key via HTTP.
+/// Runs on a libuv worker thread — does NOT block the Node.js event loop.
+pub struct VerifyGumroadTask {
+    license_key: String,
+}
 
-    std::thread::spawn(move || {
-        let client = match reqwest::blocking::Client::builder()
+impl Task for VerifyGumroadTask {
+    type Output = String;
+    type JsValue = String;
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tsfn.call(format!("ERR:client:{}", e), ThreadsafeFunctionCallMode::NonBlocking);
-                return;
-            }
-        };
+            .map_err(|e| napi::Error::from_reason(format!("ERR:client:{}", e)))?;
 
         // Try both product identifiers (product_id for new products, permalink for old ones)
         let product_ids = ["1HETxGKGYYf6DNDp5SnWVw==", "mzhzpt"];
@@ -46,7 +42,7 @@ pub fn verify_gumroad_key(license_key: String, callback: JsFunction) -> napi::Re
                 .post("https://api.gumroad.com/v2/licenses/verify")
                 .form(&[
                     ("product_id", *pid),
-                    ("license_key", license_key.as_str()),
+                    ("license_key", self.license_key.as_str()),
                     ("increment_uses_count", "true"),
                 ])
                 .send();
@@ -57,8 +53,7 @@ pub fn verify_gumroad_key(license_key: String, callback: JsFunction) -> napi::Re
                     println!("[LicenseRust] Gumroad response (pid={}): {}", pid, body);
                     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
                         if json["success"].as_bool().unwrap_or(false) {
-                            tsfn.call("OK".to_string(), ThreadsafeFunctionCallMode::NonBlocking);
-                            return;
+                            return Ok("OK".to_string());
                         }
                         last_error = json["message"].as_str().unwrap_or("unknown error").to_string();
                     } else {
@@ -71,10 +66,20 @@ pub fn verify_gumroad_key(license_key: String, callback: JsFunction) -> napi::Re
             }
         }
 
-        tsfn.call(format!("ERR:gumroad:{}", last_error), ThreadsafeFunctionCallMode::NonBlocking);
-    });
+        Ok(format!("ERR:gumroad:{}", last_error))
+    }
 
-    Ok(())
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+/// Validates a Gumroad license key by calling the Gumroad Licenses API.
+/// Returns a Promise that resolves to "OK" on success, or an error message string on failure.
+/// The HTTP call runs on a libuv worker thread to prevent blocking the Node.js event loop.
+#[napi]
+pub fn verify_gumroad_key(license_key: String) -> AsyncTask<VerifyGumroadTask> {
+    AsyncTask::new(VerifyGumroadTask { license_key })
 }
 
 fn hostname_fallback() -> String {


### PR DESCRIPTION
## Description

This PR fixes a critical crash that occurred during license activation on both Windows and macOS. The crash was caused by an implementation mismatch and architectural incompatibility between the Rust native module and Electron's N-API.

### The Problem

1.  **API Mismatch**: The Rust `verify_gumroad_key` was using a callback-based `ThreadsafeFunction` pattern, but the TypeScript code was calling it synchronously.
2.  **macOS Crash**: Electron on macOS (darwin-x64) has a known assertion failure (`Assertion failed: (func) != nullptr`) when dropping a `ThreadsafeFunction` that wasn't properly initialized or used in certain environments.
3.  **Windows Reliability**: Calling an async native function without a callback led to race conditions and "is not a function" errors in the JavaScript layer.

### The Solution: Migration to `AsyncTask`

Instead of `std::thread::spawn` and `ThreadsafeFunction`, we now use the **`AsyncTask`** pattern provided by `napi-rs`:

-   **Native Promises**: `verify_gumroad_key` now returns a native JS `Promise` directly.
-   **Libuv Thread Pool**: The blocking HTTP request (Gumroad API) is now offloaded to the libuv worker thread pool, which is the standard way to handle async I/O in Node.js/Electron.
-   **No Callbacks**: Removed the boilerplate callback logic in TypeScript, making the code cleaner and more robust.

## Changes

-   **Rust (`license.rs`)**: Implemented `Task` trait for `VerifyGumroadTask` and changed function signature to return `AsyncTask`.
-   **IPC Handlers (`ipcHandlers.ts`)**: Added explicit `await` for `activateLicense`.
-   **Module Definitions (`index.d.ts` / `index.js`)**: Updated to reflect the new asynchronous signature.

## How to Test

**IMPORTANT**: Since this change modifies the Rust native module, you **must** rebuild the native binaries for your platform after switching to this branch:

1.  `npm install`
2.  `npm run build:native`  <-- **CRITICAL**
3.  `npm start`

## Verification

-   ✅ **Windows**: Verified that license activation completes successfully with the rebuilt `.node` binary.
-   ✅ **macOS**: Fixed the SIGABRT/Assertion failure by removing `ThreadsafeFunction`. (Requires rebuild on target machine).
