### PR TITLE
Feat: add github issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Create a report to help us improve the project
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+  - ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide relevant environment details (e.g., OS, app version, Node.js version, Electron version).
+      placeholder: |
+        - OS: [e.g. Windows 11]
+        - App Version: [e.g. 1.0.0]
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant console logs, error messages, or native module output here.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Need Support or Have a Question?
+    url: https://github.com/evinjohnn/natively-cluely-ai-assistant/discussions
+    about: Please ask and answer questions here rather than creating an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Feature Request]: "
+labels: ["enhancement"]
+assignees:
+  - ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature to improve the project!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the feature is and what problem it solves.
+      placeholder: e.g. I'm always frustrated when [...] so I would like to have [...]
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- What does this PR do and why? Link to issues: Fixes #123 -->
+
+Fixes #
+
+## Type of Change
+- 🐛 Bug Fix
+- ✨ New Feature
+- 🎨 Refactor / Style Update
+- 📝 Documentation
+
+## Testing & Environment
+- [ ] Manual test performed on: **[e.g. Windows 11]**
+<!-- Describe how to verify the changes below -->
+
+## Visuals (Optional)
+<!-- Drag and drop screenshots or videos here. -->


### PR DESCRIPTION
## Summary
This PR implements the GitHub Community Health infrastructure by adding issue templates and a pull request template. This standardizes how bugs and features are reported.


## Type of Change
- ✨ New Feature
- 📝 Documentation

