### PR TITLE
Fix: auto update on windows

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,116 @@
+# Release Process & Update Channels
+
+## Update Channels
+
+Natively supports two update channels:
+
+| Channel | File | Description |
+|---------|------|-------------|
+| **stable** | `latest.yml` | Production releases for all users |
+| **beta** | `beta-latest.yml` | Pre-release testing for beta testers |
+
+### How It Works
+
+The update channel is **auto-detected** based on the version suffix:
+
+```typescript
+// electron/main.ts - setupAutoUpdater()
+const currentVersion = app.getVersion()
+if (currentVersion.includes('beta')) {
+  autoUpdater.channel = 'beta'
+} else {
+  autoUpdater.channel = 'stable'
+}
+```
+
+| Version | Channel | Updates to |
+|---------|---------|------------|
+| `2.0.7` | stable | `2.0.8`, `2.1.0` |
+| `2.0.7-beta.1` | beta | `2.0.7-beta.2`, `2.0.8-beta.1` |
+| `2.0.8` | stable | `2.0.9`, `2.1.0` |
+
+---
+
+## Release Workflow
+
+### 1. Beta Release (Testing)
+
+```bash
+# 1. Update version in package.json
+"version": "2.0.8-beta.1"
+
+# 2. Build
+npm run dist
+
+# 3. Upload to GitHub Release
+# - Tag: v2.0.8-beta.1
+# - Title: Natively v2.0.8-beta.1
+# - Mark as "Pre-release"
+# - Upload files from release/:
+#   - Natively Setup 2.0.8-beta.1.exe
+#   - Natively.2.0.8-beta.1.exe
+#   - beta-latest.yml  <-- important!
+#   - *.blockmap files
+```
+
+### 2. Stable Release (Production)
+
+```bash
+# 1. Update version in package.json
+"version": "2.0.8"
+
+# 2. Build
+npm run dist
+
+# 3. Upload to GitHub Release
+# - Tag: v2.0.8
+# - Title: Natively v2.0.8
+# - Upload files from release/:
+#   - Natively Setup 2.0.8.exe
+#   - Natively.2.0.8.exe
+#   - latest.yml  <-- important!
+#   - *.blockmap files
+```
+
+---
+
+## Platform Behavior
+
+### Windows
+- ✅ Full auto-update (check → download → install)
+- Uses NSIS installer
+
+### macOS
+- ⚠️ Semi-automatic (check → download → manual install)
+- Opens download folder in Finder for unsigned apps
+- Requires Apple Developer ($99/year) for full auto-update
+
+---
+
+## Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH[-PRERELEASE]
+
+Examples:
+2.0.7           - Stable release
+2.0.7-beta.1    - Beta pre-release
+2.0.7-beta.2    - Beta iteration
+2.1.0           - Minor feature release
+3.0.0           - Major breaking change
+```
+
+
+---
+
+## Files Created by Build
+
+| File | Purpose |
+|------|---------|
+| `latest.yml` | Stable channel manifest |
+| `beta-latest.yml` | Beta channel manifest |
+| `*.exe` | Windows installer |
+| `*.dmg` | macOS installer |
+| `*.blockmap` | Differential update support |

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -45,6 +45,40 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
+  // --- Auto-Update IPC Handlers ---
+  safeHandle("check-for-updates", async () => {
+    try {
+      console.log("[IPC] Manual update check requested");
+      await appState.checkForUpdates();
+      return { success: true };
+    } catch (err: any) {
+      console.error("[IPC] check-for-updates failed:", err);
+      return { success: false, error: err.message };
+    }
+  });
+
+  safeHandle("download-update", async () => {
+    try {
+      console.log("[IPC] Download update requested");
+      appState.downloadUpdate();
+      return { success: true };
+    } catch (err: any) {
+      console.error("[IPC] download-update failed:", err);
+      return { success: false, error: err.message };
+    }
+  });
+
+  safeHandle("quit-and-install-update", async () => {
+    try {
+      console.log("[IPC] Quit and install update requested");
+      await appState.quitAndInstallUpdate();
+      return { success: true };
+    } catch (err: any) {
+      console.error("[IPC] quit-and-install-update failed:", err);
+      return { success: false, error: err.message };
+    }
+  });
+
   safeHandle("license:activate", async (event, key: string) => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -398,6 +398,17 @@ export class AppState {
     autoUpdater.autoDownload = false
     autoUpdater.autoInstallOnAppQuit = false  // Manual install only via button
 
+    // Auto-detect update channel based on current version
+    const currentVersion = app.getVersion()
+    if (currentVersion.includes('alpha')) {
+      autoUpdater.channel = 'alpha'
+    } else if (currentVersion.includes('beta')) {
+      autoUpdater.channel = 'beta'
+    } else {
+      autoUpdater.channel = 'stable'
+    }
+    console.log(`[AutoUpdater] Channel: ${autoUpdater.channel}, Version: ${currentVersion}`)
+
     autoUpdater.on("checking-for-update", () => {
       console.log("[AutoUpdater] Checking for update...")
       this.broadcast("update-checking")

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -400,9 +400,7 @@ export class AppState {
 
     // Auto-detect update channel based on current version
     const currentVersion = app.getVersion()
-    if (currentVersion.includes('alpha')) {
-      autoUpdater.channel = 'alpha'
-    } else if (currentVersion.includes('beta')) {
+    if (currentVersion.includes('beta')) {
       autoUpdater.channel = 'beta'
     } else {
       autoUpdater.channel = 'stable'

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -550,11 +550,25 @@ export class AppState {
   }
 
   public async checkForUpdates(): Promise<void> {
-    await autoUpdater.checkForUpdatesAndNotify()
+    console.log('[AutoUpdater] Manual check for updates requested')
+    try {
+      await autoUpdater.checkForUpdatesAndNotify()
+    } catch (err: any) {
+      console.error('[AutoUpdater] checkForUpdates failed:', err)
+    }
   }
 
   public downloadUpdate(): void {
-    autoUpdater.downloadUpdate()
+    console.log('[AutoUpdater] Starting download...')
+    try {
+      autoUpdater.downloadUpdate().catch(err => {
+        console.error('[AutoUpdater] downloadUpdate failed:', err)
+        this.broadcast('update-error', err.message || 'Download failed')
+      })
+    } catch (err: any) {
+      console.error('[AutoUpdater] downloadUpdate exception:', err)
+      this.broadcast('update-error', err.message || 'Download failed')
+    }
   }
 
   // New Property for System Audio & Microphone

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -25,7 +25,7 @@ const UpdateBanner: React.FC = () => {
         // Listen for download progress
         const unsubProgress = window.electronAPI.onDownloadProgress((progressObj) => {
             // Ensure modal is visible if download starts
-            if (!isVisible) setIsVisible(true);
+            setIsVisible(true);
             setStatus('downloading');
             setDownloadProgress(progressObj.percent);
         });
@@ -53,7 +53,7 @@ const UpdateBanner: React.FC = () => {
             unsubDownloaded();
             unsubError();
         };
-    }, [isVisible]);
+    }, []);
 
     // Demo/Test mode: Press Cmd+I to trigger backend test-fetch
     useEffect(() => {

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -6,13 +6,15 @@ const UpdateBanner: React.FC = () => {
     const [parsedNotes, setParsedNotes] = useState<any>(null);
     const [isVisible, setIsVisible] = useState(false);
     const [downloadProgress, setDownloadProgress] = useState(0);
-    const [status, setStatus] = useState<'idle' | 'downloading' | 'ready'>('idle');
+    const [status, setStatus] = useState<'idle' | 'downloading' | 'ready' | 'error'>('idle');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     useEffect(() => {
         // Listen for update available
         const unsubAvailable = window.electronAPI.onUpdateAvailable((info: any) => {
             console.log('[UpdateBanner] Update available:', info);
             setUpdateInfo(info);
+            setErrorMessage(null);
             // If parsed notes are included in the info object (from our backend change)
             if (info.parsedNotes) {
                 setParsedNotes(info.parsedNotes);
@@ -38,10 +40,18 @@ const UpdateBanner: React.FC = () => {
             setIsVisible(true);
         });
 
+        // Listen for update errors
+        const unsubError = window.electronAPI.onUpdateError((err: string) => {
+            console.error('[UpdateBanner] Update error:', err);
+            setStatus('error');
+            setErrorMessage(err);
+        });
+
         return () => {
             unsubAvailable();
             unsubProgress();
             unsubDownloaded();
+            unsubError();
         };
     }, [isVisible]);
 
@@ -92,6 +102,7 @@ const UpdateBanner: React.FC = () => {
             onInstall={handleInstall}
             downloadProgress={downloadProgress}
             status={status}
+            errorMessage={errorMessage}
         />
     );
 };

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -21,7 +21,8 @@ interface UpdateModalProps {
     onDismiss: () => void;
     onInstall: () => void;
     downloadProgress: number;
-    status: 'idle' | 'downloading' | 'ready';
+    status: 'idle' | 'downloading' | 'ready' | 'error';
+    errorMessage?: string | null;
 }
 
 const UpdateModal: React.FC<UpdateModalProps> = ({
@@ -31,7 +32,8 @@ const UpdateModal: React.FC<UpdateModalProps> = ({
     onDismiss,
     onInstall,
     downloadProgress,
-    status
+    status,
+    errorMessage
 }) => {
     // Helper to format version string
     const formatVersion = (v: string) => {
@@ -199,6 +201,29 @@ const UpdateModal: React.FC<UpdateModalProps> = ({
                                     className="text-[13px] font-medium text-white/30 hover:text-white/60 transition-colors mt-auto mb-1"
                                 >
                                     Hide
+                                </button>
+                            </div>
+                        ) : status === 'error' ? (
+                            <div className="p-8 flex flex-col items-center justify-center h-full text-center relative">
+                                <div className="space-y-1.5 mb-6">
+                                    <h2 className="text-[17px] font-semibold text-white tracking-tight">
+                                        Update Failed
+                                    </h2>
+                                    <p className="text-[13px] text-red-400 font-medium">
+                                        {errorMessage || 'An error occurred while downloading the update.'}
+                                    </p>
+                                </div>
+                                <div className="bg-white/[0.03] rounded-xl border border-white/[0.06] p-4 max-w-[360px]">
+                                    <p className="text-[12px] text-white/60 leading-relaxed">
+                                        Please check your internet connection and try again. 
+                                        You can also download the latest version manually from GitHub.
+                                    </p>
+                                </div>
+                                <button
+                                    onClick={onDismiss}
+                                    className="px-5 py-[6px] bg-white/10 hover:bg-white/15 text-white text-[13px] font-medium rounded-lg mt-6 transition-colors"
+                                >
+                                    Close
                                 </button>
                             </div>
                         ) : (


### PR DESCRIPTION
## Summary

Fix auto-update functionality on Windows — update modal appeared but download never started (stuck at 0%).

**Root cause:** IPC handlers for `check-for-updates`, `download-update`, and `quit-and-install-update` were missing. The renderer called `ipcRenderer.invoke("download-update")` but no handler existed in the main process, so the request was silently ignored.

**Additional improvements:**
- Added error handling in `downloadUpdate()` and `checkForUpdates()` methods
- Added `update-error` event listener in UI to show error messages to user
- Added error state in UpdateModal for better UX when download fails
- Added auto-detection of update channel based on version suffix (stable/beta)
- Added release process documentation (`docs/RELEASE.md`)

## Type of Change
- 🐛 Bug Fix
- ✨ New Feature

## Changes

### electron/ipcHandlers.ts
- Added `check-for-updates` handler
- Added `download-update` handler  
- Added `quit-and-install-update` handler

### electron/main.ts
- Added try-catch and error broadcasting in `downloadUpdate()`
- Added try-catch in `checkForUpdates()`
- Added auto-detection of update channel based on version suffix

### src/components/UpdateBanner.tsx
- Added `update-error` event listener
- Added `error` status and `errorMessage` state

### src/components/UpdateModal.tsx
- Added `error` status type
- Added error UI state with user-friendly message

### docs/RELEASE.md
- Added release process documentation
- Described update channels (stable/beta)
- Documented version numbering and platform behavior

## Update Channels

| Version | Channel | File | Updates to |
|---------|---------|------|------------|
| `2.0.7` | stable | `latest.yml` | `2.0.8`, `2.1.0` |
| `2.0.7-beta.1` | beta | `beta-latest.yml` | `2.0.7-beta.2`, `2.0.8-beta.1` |
