### PR TITLE
fix(audio): use the correct native sample-rate API in JS wrappers

### DIFF
--- a/electron/audio/MicrophoneCapture.ts
+++ b/electron/audio/MicrophoneCapture.ts
@@ -17,6 +17,7 @@ export class MicrophoneCapture extends EventEmitter {
     private monitor: any = null;
     private isRecording: boolean = false;
     private deviceId: string | null = null;
+    private detectedSampleRate: number = 48000;
 
     constructor(deviceId?: string | null) {
         super();
@@ -28,6 +29,7 @@ export class MicrophoneCapture extends EventEmitter {
             try {
                 console.log('[MicrophoneCapture] Creating native monitor (Eager Init)...');
                 this.monitor = new RustMicCapture(this.deviceId);
+                this.refreshSampleRate();
             } catch (e) {
                 console.error('[MicrophoneCapture] Failed to create native monitor:', e);
                 // We don't throw here to allow app to start, but start() will fail
@@ -36,12 +38,32 @@ export class MicrophoneCapture extends EventEmitter {
     }
 
     public getSampleRate(): number {
-        if (this.monitor && typeof this.monitor.get_sample_rate === 'function') {
-            const nativeRate = this.monitor.get_sample_rate();
+        this.refreshSampleRate();
+        return this.detectedSampleRate;
+    }
+
+    private refreshSampleRate(): void {
+        const nativeRate = this.readNativeSampleRate();
+        if (nativeRate && nativeRate !== this.detectedSampleRate) {
+            this.detectedSampleRate = nativeRate;
             console.log(`[MicrophoneCapture] Real native rate: ${nativeRate}`);
-            return nativeRate;
         }
-        return 48000; // Safe default for most modern mics before native initialization
+    }
+
+    private readNativeSampleRate(): number | null {
+        if (!this.monitor) return null;
+
+        const getter =
+            typeof this.monitor.getSampleRate === 'function'
+                ? this.monitor.getSampleRate.bind(this.monitor)
+                : typeof this.monitor.get_sample_rate === 'function'
+                    ? this.monitor.get_sample_rate.bind(this.monitor)
+                    : null;
+
+        if (!getter) return null;
+
+        const nativeRate = Number(getter());
+        return Number.isFinite(nativeRate) && nativeRate > 0 ? nativeRate : null;
     }
 
     /**
@@ -60,6 +82,7 @@ export class MicrophoneCapture extends EventEmitter {
             console.log('[MicrophoneCapture] Monitor not initialized. Re-initializing...');
             try {
                 this.monitor = new RustMicCapture(this.deviceId);
+                this.refreshSampleRate();
             } catch (e) {
                 this.emit('error', e);
                 return;

--- a/electron/audio/SystemAudioCapture.ts
+++ b/electron/audio/SystemAudioCapture.ts
@@ -31,15 +31,32 @@ export class SystemAudioCapture extends EventEmitter {
     }
 
     public getSampleRate(): number {
-        if (this.monitor && typeof this.monitor.get_sample_rate === 'function') {
-            const nativeRate = this.monitor.get_sample_rate();
-            if (nativeRate !== this.detectedSampleRate) {
-                console.log(`[SystemAudioCapture] Real native rate: ${nativeRate}`);
-                this.detectedSampleRate = nativeRate;
-            }
-            return nativeRate;
-        }
+        this.refreshSampleRate();
         return this.detectedSampleRate;
+    }
+
+    private refreshSampleRate(): void {
+        const nativeRate = this.readNativeSampleRate();
+        if (nativeRate && nativeRate !== this.detectedSampleRate) {
+            console.log(`[SystemAudioCapture] Real native rate: ${nativeRate}`);
+            this.detectedSampleRate = nativeRate;
+        }
+    }
+
+    private readNativeSampleRate(): number | null {
+        if (!this.monitor) return null;
+
+        const getter =
+            typeof this.monitor.getSampleRate === 'function'
+                ? this.monitor.getSampleRate.bind(this.monitor)
+                : typeof this.monitor.get_sample_rate === 'function'
+                    ? this.monitor.get_sample_rate.bind(this.monitor)
+                    : null;
+
+        if (!getter) return null;
+
+        const nativeRate = Number(getter());
+        return Number.isFinite(nativeRate) && nativeRate > 0 ? nativeRate : null;
     }
 
     /**
@@ -59,6 +76,7 @@ export class SystemAudioCapture extends EventEmitter {
             console.log('[SystemAudioCapture] Creating native monitor (lazy init)...');
             try {
                 this.monitor = new RustAudioCapture(this.deviceId);
+                this.refreshSampleRate();
             } catch (e) {
                 console.error('[SystemAudioCapture] Failed to create native monitor:', e);
                 this.emit('error', e);
@@ -69,11 +87,7 @@ export class SystemAudioCapture extends EventEmitter {
         try {
             console.log('[SystemAudioCapture] Starting native capture...');
             
-            // Fetch real sample rate as soon as monitor starts
-            if (typeof this.monitor.get_sample_rate === 'function') {
-                this.detectedSampleRate = this.monitor.get_sample_rate();
-                console.log(`[SystemAudioCapture] Detected sample rate: ${this.detectedSampleRate}`);
-            }
+            this.refreshSampleRate();
 
             this.monitor.start((chunk: Uint8Array) => {
                 // The native module sends raw PCM bytes (Uint8Array) via zero-copy napi::Buffer


### PR DESCRIPTION
## Summary
Fixes meeting STT sample-rate setup by reading the native audio addon’s real sample-rate API instead of falling back to `48000Hz`.

Fixes #

## Type of Change
- 🐛 Bug Fix

## Detailed Changes
- use native `getSampleRate()` as the primary wrapper API
- keep `get_sample_rate()` as a compatibility fallback for older local binaries
- cache and log detected native sample rates instead of always using `48000`

## Testing & Environment
- [x] Manual test performed on: **macOS Sequoia / Apple Silicon**
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npx tsc -p tsconfig.json --noEmit`
- packaged meeting test previously confirmed mic transcription works correctly in both backends with this fix applied

## Visuals (Optional)
N/A
