### PR TITLE
fix(mac): unify native mic test, permissions, and packaged diagnostics

### DIFF
--- a/electron/audio/MicrophoneCapture.ts
+++ b/electron/audio/MicrophoneCapture.ts
@@ -30,7 +30,7 @@ export class MicrophoneCapture extends EventEmitter {
                 this.monitor = new RustMicCapture(this.deviceId);
             } catch (e) {
                 console.error('[MicrophoneCapture] Failed to create native monitor:', e);
-                // We don't throw here to allow app to start, but start() will fail
+                throw e;
             }
         }
     }

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1364,7 +1364,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   safeHandle("start-audio-test", async (event, deviceId?: string) => {
-    appState.startAudioTest(deviceId);
+    await appState.startAudioTest(deviceId);
     return { success: true };
   });
 
@@ -2148,4 +2148,3 @@ export function initializeIpcHandlers(appState: AppState): void {
     return;
   });
 }
-

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, shell } from "electron"
+import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, shell, systemPreferences } from "electron"
 import path from "path"
 import fs from "fs"
 import { autoUpdater } from "electron-updater"
@@ -25,16 +25,33 @@ const originalLog = console.log;
 const originalWarn = console.warn;
 const originalError = console.error;
 
-const isDev = process.env.NODE_ENV === "development";
-
 function logToFile(msg: string) {
-  // Only log to file in development
-  if (!isDev) return;
-
   try {
-    require('fs').appendFileSync(logFile, new Date().toISOString() + ' ' + msg + '\n');
+    fs.appendFileSync(logFile, new Date().toISOString() + ' ' + msg + '\n');
   } catch (e) {
     // Ignore logging errors
+  }
+}
+
+async function ensureMacMicrophoneAccess(context: string): Promise<boolean> {
+  if (process.platform !== 'darwin') return true;
+
+  try {
+    const currentStatus = systemPreferences.getMediaAccessStatus('microphone');
+    console.log(`[Main] macOS microphone permission before ${context}: ${currentStatus}`);
+
+    if (currentStatus === 'granted') {
+      return true;
+    }
+
+    const granted = await systemPreferences.askForMediaAccess('microphone');
+    console.log(
+      `[Main] macOS microphone permission request during ${context}: ${granted ? 'granted' : 'denied'}`
+    );
+    return granted;
+  } catch (error) {
+    console.error(`[Main] Failed to check macOS microphone permission during ${context}:`, error);
+    return false;
   }
 }
 
@@ -871,20 +888,23 @@ export class AppState {
   }
 
 
-  public startAudioTest(deviceId?: string): void {
+  public async startAudioTest(deviceId?: string): Promise<void> {
     console.log(`[Main] Starting Audio Test on device: ${deviceId || 'default'}`);
     this.stopAudioTest(); // Stop any existing test
 
-    try {
-      this.audioTestCapture = new MicrophoneCapture(deviceId || undefined);
-      this.audioTestCapture.start();
+    if (!(await ensureMacMicrophoneAccess('audio test'))) {
+      throw new Error('Microphone access denied. Please allow microphone access in System Settings and try again.');
+    }
 
-      // Send to settings window if open, else main window
-      const win = this.settingsWindowHelper.getSettingsWindow() || this.getMainWindow();
+    const attachAudioTestListeners = (capture: MicrophoneCapture) => {
+      capture.on('data', (chunk: Buffer) => {
+        const targets = [
+          this.settingsWindowHelper.getSettingsWindow(),
+          this.getWindowHelper().getLauncherWindow(),
+          this.getWindowHelper().getOverlayWindow(),
+        ].filter((win): win is BrowserWindow => !!win && !win.isDestroyed());
 
-      this.audioTestCapture.on('data', (chunk: Buffer) => {
-        // Calculate basic RMS for level meter
-        if (!win || win.isDestroyed()) return;
+        if (targets.length === 0) return;
 
         let sum = 0;
         const step = 10;
@@ -898,18 +918,32 @@ export class AppState {
         const count = len / (2 * step);
         if (count > 0) {
           const rms = Math.sqrt(sum / count);
-          // Normalize 0-1 (heuristic scaling, max comfortable mic input is around 10000-20000)
           const level = Math.min(rms / 10000, 1.0);
-          win.webContents.send('audio-level', level);
+          for (const target of targets) {
+            target.webContents.send('audio-test-level', level);
+          }
         }
       });
 
-      this.audioTestCapture.on('error', (err: Error) => {
+      capture.on('error', (err: Error) => {
         console.error('[Main] AudioTest Error:', err);
       });
+    };
 
+    try {
+      this.audioTestCapture = new MicrophoneCapture(deviceId || undefined);
+      attachAudioTestListeners(this.audioTestCapture);
+      this.audioTestCapture.start();
     } catch (err) {
-      console.error('[Main] Failed to start audio test:', err);
+      console.warn('[Main] Failed to start audio test on preferred device. Falling back to default.', err);
+      try {
+        this.audioTestCapture = new MicrophoneCapture();
+        attachAudioTestListeners(this.audioTestCapture);
+        this.audioTestCapture.start();
+      } catch (fallbackErr) {
+        console.error('[Main] Failed to start audio test:', fallbackErr);
+        throw fallbackErr;
+      }
     }
   }
 
@@ -931,6 +965,12 @@ export class AppState {
 
   public async startMeeting(metadata?: any): Promise<void> {
     console.log('[Main] Starting Meeting...', metadata);
+
+    if (!(await ensureMacMicrophoneAccess('meeting start'))) {
+      const message = 'Microphone access denied. Please allow microphone access in System Settings.';
+      this.broadcast('meeting-audio-error', message);
+      throw new Error(message);
+    }
 
     this.isMeetingActive = true;
     if (metadata) {

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -1015,12 +1015,6 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
     const [calendarStatus, setCalendarStatus] = useState<{ connected: boolean; email?: string }>({ connected: false });
     const [isCalendarsLoading, setIsCalendarsLoading] = useState(false);
 
-    const audioContextRef = React.useRef<AudioContext | null>(null);
-    const analyserRef = React.useRef<AnalyserNode | null>(null);
-    const sourceRef = React.useRef<MediaStreamAudioSourceNode | null>(null);
-    const rafRef = React.useRef<number | null>(null);
-    const streamRef = React.useRef<MediaStream | null>(null);
-
     // Load stored credentials on mount
 
 
@@ -1132,112 +1126,30 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
         }
     }, [isOpen, selectedInput, selectedOutput]); // Re-run if isOpen changes, or if selected devices are cleared
 
-    // Effect for real-time audio level monitoring
+    // Use the native mic test path so device IDs stay consistent with the meeting runtime.
     useEffect(() => {
         if (isOpen && activeTab === 'audio') {
-            let mounted = true;
+            const unsubscribe = window.electronAPI?.onAudioTestLevel?.((level) => {
+                setMicLevel(Math.max(0, Math.min(100, level * 100)));
+            });
 
-            const startAudio = async () => {
-                try {
-                    // Cleanup previous audio context if it exists
-                    if (audioContextRef.current) {
-                        audioContextRef.current.close();
-                    }
-
-                    const stream = await navigator.mediaDevices.getUserMedia({
-                        audio: {
-                            deviceId: selectedInput ? { exact: selectedInput } : undefined
-                        }
-                    });
-
-                    streamRef.current = stream;
-
-                    if (!mounted) return;
-
-                    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
-                    const analyser = audioContext.createAnalyser();
-                    const source = audioContext.createMediaStreamSource(stream);
-
-                    analyser.fftSize = 256;
-                    source.connect(analyser);
-
-                    audioContextRef.current = audioContext;
-                    analyserRef.current = analyser;
-                    sourceRef.current = source;
-
-                    const dataArray = new Uint8Array(analyser.frequencyBinCount);
-                    let smoothLevel = 0;
-
-                    const updateLevel = () => {
-                        if (!mounted || !analyserRef.current) return;
-                        // Use Time Domain Data for accurate volume (waveform) instead of frequency
-                        analyserRef.current.getByteTimeDomainData(dataArray);
-
-                        let sum = 0;
-                        for (let i = 0; i < dataArray.length; i++) {
-                            // Convert 0-255 to -1 to 1 range
-                            const value = (dataArray[i] - 128) / 128;
-                            sum += value * value;
-                        }
-
-                        // Calculate RMS
-                        const rms = Math.sqrt(sum / dataArray.length);
-
-                        // Convert to simpler 0-100 range with some boost
-                        // RMS is usually very small (0.01 - 0.5 for normal speech)
-                        // Logarithmic scaling feels more natural for volume
-                        const db = 20 * Math.log10(rms);
-                        // Approximate mapping: -60dB (silence) to 0dB (max) -> 0 to 100
-                        const targetLevel = Math.max(0, Math.min(100, (db + 60) * 2));
-
-                        // Apply smoothing
-                        if (targetLevel > smoothLevel) {
-                            smoothLevel = smoothLevel * 0.7 + targetLevel * 0.3; // Fast attack
-                        } else {
-                            smoothLevel = smoothLevel * 0.95 + targetLevel * 0.05; // Slow decay
-                        }
-
-                        setMicLevel(smoothLevel);
-
-                        rafRef.current = requestAnimationFrame(updateLevel);
-                    };
-
-                    updateLevel();
-                } catch (error) {
-                    console.error("Error accessing microphone:", error);
-                    setMicLevel(0); // Reset level on error
-                }
-            };
-
-            startAudio();
+            window.electronAPI?.startAudioTest(selectedInput || undefined).catch((error) => {
+                console.error("Error starting native microphone test:", error);
+                setMicLevel(0);
+            });
 
             return () => {
-                mounted = false;
-                if (rafRef.current) cancelAnimationFrame(rafRef.current);
-                if (sourceRef.current) sourceRef.current.disconnect();
-                if (audioContextRef.current) {
-                    audioContextRef.current.close();
-                    audioContextRef.current = null;
-                }
-                if (streamRef.current) {
-                    streamRef.current.getTracks().forEach(track => track.stop());
-                    streamRef.current = null;
-                }
-                setMicLevel(0); // Reset mic level on cleanup
+                unsubscribe?.();
+                window.electronAPI?.stopAudioTest?.().catch((error) => {
+                    console.error("Error stopping native microphone test:", error);
+                });
+                setMicLevel(0);
             };
         } else {
-            // Cleanup when closing tab or overlay or switching away from audio tab
-            if (rafRef.current) cancelAnimationFrame(rafRef.current);
-            if (sourceRef.current) sourceRef.current.disconnect(); // Disconnect source as well
-            if (audioContextRef.current) {
-                audioContextRef.current.close();
-                audioContextRef.current = null;
-            }
-            if (streamRef.current) {
-                streamRef.current.getTracks().forEach(track => track.stop());
-                streamRef.current = null;
-            }
             setMicLevel(0);
+            window.electronAPI?.stopAudioTest?.().catch((error) => {
+                console.error("Error stopping native microphone test:", error);
+            });
         }
     }, [isOpen, activeTab, selectedInput]);
 


### PR DESCRIPTION
## Summary
Makes the settings mic test use the same native path as meetings, fixes the audio-test event wiring, and improves packaged macOS microphone diagnostics.

Fixes #

## Type of Change
- 🐛 Bug Fix

## Detailed Changes
- route the settings mic meter through native `startAudioTest`
- fix the emitted/listened audio-test event name mismatch for mic levels
- explicitly check/request macOS microphone permission before audio test and meeting start
- keep packaged file logging enabled for audio debugging
- surface native microphone init failures instead of swallowing them

## Testing & Environment
- [x] Manual test performed on: **macOS Sequoia / Apple Silicon**
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npx tsc -p tsconfig.json --noEmit`
- settings mic meter now matches the actual native meeting capture path
- packaged logs include audio-test and meeting startup diagnostics

## Visuals (Optional)
N/A
