### PR TITLE
chore(audio): improve transcript and runtime observability

### DIFF
--- a/electron/SessionTracker.ts
+++ b/electron/SessionTracker.ts
@@ -202,6 +202,12 @@ export class SessionTracker {
      * Handle incoming transcript from native audio service
      */
     handleTranscript(segment: TranscriptSegment): { role: 'interviewer' | 'user' | 'assistant' } | null {
+        if (segment.speaker === 'user') {
+            if (Math.random() < 0.05 || segment.final) {
+                console.log(`[SessionTracker] RX User Segment: Final=${segment.final} Text="${segment.text.substring(0, 50)}..."`);
+            }
+        }
+
         // Track interim segments for interviewer to prevent data loss on stop
         if (segment.speaker === 'interviewer') {
             if (Math.random() < 0.05 || segment.final) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -947,6 +947,10 @@ export class AppState {
     // setTimeout(100) ensures setWindowMode IPC is processed first.
     setTimeout(async () => {
       try {
+        const requestedInputDeviceId = metadata?.audio?.inputDeviceId || 'default';
+        const requestedOutputDeviceId = metadata?.audio?.outputDeviceId || 'default';
+        const requestedBackend = requestedOutputDeviceId === 'sck' ? 'sck' : 'coreaudio';
+
         // Check for audio configuration preference
         if (metadata?.audio) {
           await this.reconfigureAudio(metadata.audio.inputDeviceId, metadata.audio.outputDeviceId);
@@ -954,6 +958,12 @@ export class AppState {
 
         // LAZY INIT: Ensure pipeline is ready (if not reconfigured above)
         this.setupSystemAudioPipeline();
+
+        const systemRate = this.systemAudioCapture?.getSampleRate() ?? 48000;
+        const microphoneRate = this.microphoneCapture?.getSampleRate() ?? 48000;
+        console.log(
+          `[Main] Meeting audio routing: input=${requestedInputDeviceId}, output=${requestedOutputDeviceId}, backend=${requestedBackend}, systemRate=${systemRate}Hz, micRate=${microphoneRate}Hz, interviewerSttRate=${systemRate}Hz, userSttRate=${microphoneRate}Hz`
+        );
 
         // Start System Audio
         this.systemAudioCapture?.start();

--- a/native-module/index.js
+++ b/native-module/index.js
@@ -310,6 +310,12 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
+console.log(
+  '[natively-audio] Loaded native addon source:',
+  localFileExisted ? 'local bundled binary' : 'platform package',
+  `(platform=${platform}, arch=${arch})`
+)
+
 const { getHardwareId, verifyGumroadKey, SystemAudioCapture, MicrophoneCapture, getInputDevices, getOutputDevices } = nativeBinding
 
 module.exports.getHardwareId = getHardwareId


### PR DESCRIPTION
## Summary
Adds the minimum runtime logging needed to distinguish real audio bugs from stale-artifact or routing issues in future investigations.

Fixes #

## Type of Change
- 🐛 Bug Fix
- 📝 Documentation

## Detailed Changes
- log final user transcript segments alongside interviewer transcript logs
- log input device, output device, backend, native sample rate, and STT sample rate at meeting start
- log whether the native addon was loaded from a local bundled binary or a platform package

## Testing & Environment
- [x] Manual test performed on: **macOS Sequoia / Apple Silicon**
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npx tsc -p tsconfig.json --noEmit`
- packaged logs now show transcript roles and runtime audio configuration more clearly

## Visuals (Optional)
N/A
