### PR TITLE
feat(overlay): add mouse passthrough mode for the meeting overlay

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -57,6 +57,31 @@ export class WindowHelper {
     });
   }
 
+  private isOverlayMousePassthroughEnabled(): boolean {
+    return this.appState.getOverlayMousePassthrough()
+  }
+
+  private getOverlayShowInactive(inactive?: boolean): boolean {
+    return !!inactive || this.isOverlayMousePassthroughEnabled()
+  }
+
+  private applyOverlayInteractionPolicy(): void {
+    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return
+
+    const enableMousePassthrough = this.isOverlayMousePassthroughEnabled()
+    this.overlayWindow.setIgnoreMouseEvents(
+      enableMousePassthrough,
+      enableMousePassthrough ? { forward: true } : undefined
+    )
+
+    if (process.platform === 'darwin' || process.platform === 'win32') {
+      this.overlayWindow.setFocusable(!enableMousePassthrough)
+    }
+  }
+
+  public syncOverlayInteractionPolicy(): void {
+    this.applyOverlayInteractionPolicy()
+  }
   public setWindowDimensions(width: number, height: number): void {
     const activeWindow = this.getMainWindow(); // Gets currently focused/relevant window
     if (!activeWindow || activeWindow.isDestroyed()) return
@@ -234,6 +259,7 @@ export class WindowHelper {
 
     this.overlayWindow = new BrowserWindow(overlaySettings)
     this.overlayWindow.setContentProtection(this.contentProtection)
+    this.applyOverlayInteractionPolicy()
 
     if (process.platform === "darwin") {
       this.overlayWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
@@ -340,6 +366,7 @@ export class WindowHelper {
   // Used by IPC handlers to show the overlay independently.
   public showOverlay(): void {
     if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
+      this.applyOverlayInteractionPolicy();
       this.overlayWindow.showInactive();
     }
   }
@@ -387,6 +414,7 @@ export class WindowHelper {
   public switchToOverlay(inactive?: boolean): void {
     console.log(`[WindowHelper] Switching to OVERLAY (inactive: ${!!inactive})`);
     this.currentWindowMode = 'overlay';
+    const showInactive = this.getOverlayShowInactive(inactive)
 
     // Tell the overlay renderer to expand to full size (e.g. after being minimised)
     this.overlayWindow?.webContents.send('ensure-expanded');
@@ -403,11 +431,12 @@ export class WindowHelper {
       const y = Math.floor(workArea.y + (workArea.height - 600) / 2)
 
       this.overlayWindow.setBounds({ x, y, width: 600, height: targetHeight });
+      this.applyOverlayInteractionPolicy()
 
       if (process.platform === 'win32' && this.contentProtection) {
         // Opacity Shield: Show at 0 opacity first to prevent frame leak
         this.overlayWindow.setOpacity(0);
-        if (inactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
+        if (showInactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
         this.overlayWindow.setContentProtection(true);
         // Small delay to ensure Windows DWM processes the flag before making it opaque
 
@@ -415,15 +444,16 @@ export class WindowHelper {
         this.opacityTimeout = setTimeout(() => {
           if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
             this.overlayWindow.setOpacity(1);
-            if (!inactive) this.overlayWindow.focus();
+            this.applyOverlayInteractionPolicy();
+            if (!showInactive) this.overlayWindow.focus();
             // Note: do NOT call setAlwaysOnTop here — it triggers NSApp activation on macOS
           }
         }, 60);
       } else {
         this.overlayWindow.setContentProtection(this.contentProtection);
-        if (inactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
+        if (showInactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
         // Only grab focus for explicit user-initiated shows (not shortcut/ghost shows)
-        if (!inactive) this.overlayWindow.focus();
+        if (!showInactive) this.overlayWindow.focus();
         // Do NOT re-assert setAlwaysOnTop on every show — it was set at creation time and
         // persists across hide/show cycles. Calling it again triggers [NSApp activate] on
         // macOS, stealing focus from Zoom/browser even when showInactive() was used.

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -491,6 +491,16 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true }
   })
 
+  safeHandle("set-overlay-mouse-passthrough", async (_, state: boolean) => {
+    appState.setOverlayMousePassthrough(state)
+    return { success: true }
+  })
+
+  safeHandle("toggle-overlay-mouse-passthrough", async () => {
+    const enabled = appState.toggleOverlayMousePassthrough()
+    return { success: true, enabled }
+  })
+
   safeHandle("set-disguise", async (_, mode: 'terminal' | 'settings' | 'activity' | 'none') => {
     appState.setDisguise(mode)
     return { success: true }
@@ -498,6 +508,10 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   safeHandle("get-undetectable", async () => {
     return appState.getUndetectable()
+  })
+
+  safeHandle("get-overlay-mouse-passthrough", async () => {
+    return appState.getOverlayMousePassthrough()
   })
 
   safeHandle("get-disguise", async () => {
@@ -2215,4 +2229,3 @@ export function initializeIpcHandlers(appState: AppState): void {
     return;
   });
 }
-

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -146,6 +146,7 @@ export class AppState {
   // View management
   private view: "queue" | "solutions" = "queue"
   private isUndetectable: boolean = false
+  private overlayMousePassthrough: boolean = false
 
   private problemInfo: {
     problem_statement: string
@@ -224,6 +225,8 @@ export class AppState {
       try {
         if (actionId === 'general:toggle-visibility') {
           this.toggleMainWindow();
+        } else if (actionId === 'general:toggle-mouse-passthrough') {
+          this.toggleOverlayMousePassthrough();
         } else if (actionId === 'general:take-screenshot') {
           const screenshotPath = await this.takeScreenshot(false);
           const preview = await this.getImagePreview(screenshotPath);
@@ -1142,6 +1145,7 @@ export class AppState {
     console.log('[Main] Ending Meeting...');
     this.isMeetingActive = false; // Block new data immediately
     this.broadcastMeetingState();
+    this.setOverlayMousePassthrough(false);
 
     // 3. Stop System Audio
     this.systemAudioCapture?.stop();
@@ -1830,6 +1834,26 @@ export class AppState {
 
   public getUndetectable(): boolean {
     return this.isUndetectable
+  }
+
+  public setOverlayMousePassthrough(state: boolean): void {
+    if (this.overlayMousePassthrough === state) return;
+
+    console.log(`[Overlay] setOverlayMousePassthrough(${state}) called`);
+
+    this.overlayMousePassthrough = state;
+    this.windowHelper.syncOverlayInteractionPolicy();
+    this._broadcastToAllWindows('overlay-mouse-passthrough-changed', state);
+  }
+
+  public toggleOverlayMousePassthrough(): boolean {
+    const next = !this.overlayMousePassthrough;
+    this.setOverlayMousePassthrough(next);
+    return next;
+  }
+
+  public getOverlayMousePassthrough(): boolean {
+    return this.overlayMousePassthrough;
   }
 
   public getVerboseLogging(): boolean {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -161,6 +161,10 @@ interface ElectronAPI {
   onEnsureExpanded: (callback: () => void) => () => void
   onToggleExpand: (callback: () => void) => () => void
   toggleAdvancedSettings: () => Promise<void>
+  setOverlayMousePassthrough: (enabled: boolean) => Promise<{ success: boolean }>
+  toggleOverlayMousePassthrough: () => Promise<{ success: boolean; enabled: boolean }>
+  getOverlayMousePassthrough: () => Promise<boolean>
+  onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => () => void
 
   // Streaming listeners
   streamGeminiChat: (message: string, imagePaths?: string[], context?: string, options?: { skipSystemPrompt?: boolean }) => Promise<void>
@@ -434,6 +438,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   openExternal: (url: string) => ipcRenderer.invoke("open-external", url),
   setUndetectable: (state: boolean) => ipcRenderer.invoke("set-undetectable", state),
   getUndetectable: () => ipcRenderer.invoke("get-undetectable"),
+  setOverlayMousePassthrough: (enabled: boolean) => ipcRenderer.invoke("set-overlay-mouse-passthrough", enabled),
+  toggleOverlayMousePassthrough: () => ipcRenderer.invoke("toggle-overlay-mouse-passthrough"),
+  getOverlayMousePassthrough: () => ipcRenderer.invoke("get-overlay-mouse-passthrough"),
   setOpenAtLogin: (open: boolean) => ipcRenderer.invoke("set-open-at-login", open),
   getOpenAtLogin: () => ipcRenderer.invoke("get-open-at-login"),
   setDisguise: (mode: 'terminal' | 'settings' | 'activity' | 'none') => ipcRenderer.invoke("set-disguise", mode),
@@ -761,6 +768,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on('undetectable-changed', subscription)
     return () => {
       ipcRenderer.removeListener('undetectable-changed', subscription)
+    }
+  },
+
+  onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => {
+    const subscription = (_: any, enabled: boolean) => callback(enabled)
+    ipcRenderer.on('overlay-mouse-passthrough-changed', subscription)
+    return () => {
+      ipcRenderer.removeListener('overlay-mouse-passthrough-changed', subscription)
     }
   },
 

--- a/electron/services/KeybindManager.ts
+++ b/electron/services/KeybindManager.ts
@@ -13,6 +13,7 @@ export interface KeybindConfig {
 export const DEFAULT_KEYBINDS: KeybindConfig[] = [
     // General
     { id: 'general:toggle-visibility', label: 'Toggle Visibility', accelerator: 'CommandOrControl+B', isGlobal: true, defaultAccelerator: 'CommandOrControl+B' },
+    { id: 'general:toggle-mouse-passthrough', label: 'Toggle Mouse Passthrough', accelerator: 'CommandOrControl+Shift+B', isGlobal: true, defaultAccelerator: 'CommandOrControl+Shift+B' },
     { id: 'general:process-screenshots', label: 'Process Screenshots', accelerator: 'CommandOrControl+Enter', isGlobal: true, defaultAccelerator: 'CommandOrControl+Enter' },
     { id: 'general:capture-and-process', label: 'Capture Screen & Ask AI (Global)', accelerator: 'CommandOrControl+Shift+Enter', isGlobal: true, defaultAccelerator: 'CommandOrControl+Shift+Enter' },
     { id: 'general:reset-cancel', label: 'Reset / Cancel', accelerator: 'CommandOrControl+R', isGlobal: true, defaultAccelerator: 'CommandOrControl+R' },

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -118,6 +118,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({ onEndMeeting, ove
 
     // Settings State with Persistence
     const [isUndetectable, setIsUndetectable] = useState(false);
+    const [isMousePassthrough, setIsMousePassthrough] = useState(false);
     const [hideChatHidesWidget, setHideChatHidesWidget] = useState(() => {
         const stored = localStorage.getItem('natively_hideChatHidesWidget');
         return stored ? stored === 'true' : true;
@@ -183,6 +184,19 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({ onEndMeeting, ove
         if (window.electronAPI?.onUndetectableChanged) {
             const unsubscribe = window.electronAPI.onUndetectableChanged((state) => {
                 setIsUndetectable(state);
+            });
+            return () => unsubscribe();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (window.electronAPI?.getOverlayMousePassthrough) {
+            window.electronAPI.getOverlayMousePassthrough().then(setIsMousePassthrough);
+        }
+
+        if (window.electronAPI?.onOverlayMousePassthroughChanged) {
+            const unsubscribe = window.electronAPI.onOverlayMousePassthroughChanged((enabled) => {
+                setIsMousePassthrough(enabled);
             });
             return () => unsubscribe();
         }
@@ -1632,6 +1646,7 @@ Provide only the answer, nothing else.`;
                             onQuit={() => onEndMeeting ? onEndMeeting() : window.electronAPI.quitApp()}
                             appearance={appearance}
                             onLogoClick={() => window.electronAPI?.setWindowMode?.('launcher')}
+                            mousePassthroughEnabled={isMousePassthrough}
                         />
                         <div
                             className={`relative w-[600px] max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface ${overlayPanelClass}`}

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -5,7 +5,7 @@ import {
     ArrowUp, ArrowDown, ArrowLeft, ArrowRight,
     Camera, RotateCcw, Eye, Layout, MessageSquare, Crop,
     ChevronDown, ChevronUp, Check, BadgeCheck, Power, Palette, Calendar, Ghost, Sun, Moon, RefreshCw, Info, Globe, FlaskConical, Terminal, Settings, Activity, ExternalLink, Trash2,
-    Sparkles, Pencil, Briefcase, Building2, Search, MapPin, CheckCircle, HelpCircle, Zap, SlidersHorizontal,
+    Sparkles, Pencil, Briefcase, Building2, Search, MapPin, CheckCircle, HelpCircle, Zap, SlidersHorizontal, PointerOff,
     Star, AlertCircle, Gift
 } from 'lucide-react';
 import { analytics } from '../lib/analytics/analytics.service';
@@ -383,6 +383,7 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
     
     const { shortcuts, updateShortcut, resetShortcuts } = useShortcuts();
     const [isUndetectable, setIsUndetectable] = useState(false);
+    const [isMousePassthrough, setIsMousePassthrough] = useState(false);
     const [disguiseMode, setDisguiseMode] = useState<'terminal' | 'settings' | 'activity' | 'none'>('none');
     const [openOnLogin, setOpenOnLogin] = useState(false);
     const [themeMode, setThemeMode] = useState<'system' | 'light' | 'dark'>('system');
@@ -426,6 +427,7 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
             
             // Fetch true initial state from main process
             window.electronAPI?.getUndetectable?.().then(setIsUndetectable).catch(() => { });
+            window.electronAPI?.getOverlayMousePassthrough?.().then(setIsMousePassthrough).catch(() => { });
             window.electronAPI?.getDisguise?.().then(setDisguiseMode).catch(() => { });
             window.electronAPI?.getVerboseLogging?.().then(setVerboseLogging).catch(() => { });
         }
@@ -444,6 +446,15 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
         if (window.electronAPI?.onDisguiseChanged) {
             const unsubscribe = window.electronAPI.onDisguiseChanged((newMode: any) => {
                 setDisguiseMode(newMode);
+            });
+            return () => unsubscribe();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (window.electronAPI?.onOverlayMousePassthroughChanged) {
+            const unsubscribe = window.electronAPI.onOverlayMousePassthroughChanged((enabled: boolean) => {
+                setIsMousePassthrough(enabled);
             });
             return () => unsubscribe();
         }
@@ -1310,6 +1321,29 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
                                             <p className="text-xs text-text-secondary mb-2">Customize how Natively works for you</p>
 
                                             <div className="space-y-4">
+                                                {/* Mouse Passthrough */}
+                                                <div className="flex items-center justify-between">
+                                                    <div className="flex items-center gap-4">
+                                                        <div className={`w-10 h-10 bg-bg-item-surface rounded-lg border flex items-center justify-center transition-colors ${isMousePassthrough ? 'border-sky-500/40 text-sky-400' : 'border-border-subtle text-text-tertiary'}`}>
+                                                            <PointerOff size={20} />
+                                                        </div>
+                                                        <div>
+                                                            <h3 className="text-sm font-bold text-text-primary">Mouse Passthrough</h3>
+                                                            <p className="text-xs text-text-secondary mt-0.5">Keep the overlay visible, but let hover and clicks go to the app underneath. Use shortcuts while it is on.</p>
+                                                        </div>
+                                                    </div>
+                                                    <div
+                                                        onClick={() => {
+                                                            const newState = !isMousePassthrough;
+                                                            setIsMousePassthrough(newState);
+                                                            window.electronAPI?.setOverlayMousePassthrough(newState);
+                                                        }}
+                                                        className={`w-11 h-6 rounded-full relative transition-colors ${isMousePassthrough ? 'bg-sky-500' : 'bg-bg-toggle-switch border border-border-muted'}`}
+                                                    >
+                                                        <div className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white transition-transform ${isMousePassthrough ? 'translate-x-5' : 'translate-x-0'}`} />
+                                                    </div>
+                                                </div>
+
                                                 {/* Open at Login */}
                                                 <div className="flex items-center justify-between">
                                                     <div className="flex items-center gap-4">
@@ -2519,6 +2553,16 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({ isOpen, onClose, init
                                                     <KeyRecorder
                                                         currentKeys={shortcuts.toggleVisibility}
                                                         onSave={(keys) => updateShortcut('toggleVisibility', keys)}
+                                                    />
+                                                </div>
+                                                <div className="flex items-center justify-between py-1.5 group">
+                                                    <div className="flex items-center gap-3">
+                                                        <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><PointerOff size={14} /></span>
+                                                        <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">Toggle Mouse Passthrough</span>
+                                                    </div>
+                                                    <KeyRecorder
+                                                        currentKeys={shortcuts.toggleMousePassthrough}
+                                                        onSave={(keys) => updateShortcut('toggleMousePassthrough', keys)}
                                                     />
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">

--- a/src/components/SettingsPopup.tsx
+++ b/src/components/SettingsPopup.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
-import { MessageSquare, Link, Camera, Zap, Heart, User } from 'lucide-react';
+import { MessageSquare, Link, Camera, Zap, Heart, User, PointerOff } from 'lucide-react';
 import { useShortcuts } from '../hooks/useShortcuts';
 import { useResolvedTheme } from '../hooks/useResolvedTheme';
 
@@ -7,6 +7,7 @@ const SettingsPopup = () => {
     const { shortcuts } = useShortcuts();
     const isLightTheme = useResolvedTheme() === 'light';
     const [isUndetectable, setIsUndetectable] = useState(false);
+    const [isMousePassthrough, setIsMousePassthrough] = useState(false);
     const [useGroqFastText, setUseGroqFastText] = useState(() => {
         return localStorage.getItem('natively_groq_fast_text') === 'true';
     });
@@ -69,6 +70,11 @@ const SettingsPopup = () => {
                 setIsUndetectable(state);
             });
         }
+        if (window.electronAPI?.getOverlayMousePassthrough) {
+            window.electronAPI.getOverlayMousePassthrough().then((state: boolean) => {
+                setIsMousePassthrough(state);
+            });
+        }
     }, []);
 
     // One-way listener: receive state changes from main process, never echo back
@@ -77,6 +83,15 @@ const SettingsPopup = () => {
             const unsubscribe = window.electronAPI.onUndetectableChanged((newState: boolean) => {
                 setIsUndetectable(newState);
                 localStorage.setItem('natively_undetectable', String(newState));
+            });
+            return () => unsubscribe();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (window.electronAPI?.onOverlayMousePassthroughChanged) {
+            const unsubscribe = window.electronAPI.onOverlayMousePassthroughChanged((enabled: boolean) => {
+                setIsMousePassthrough(enabled);
             });
             return () => unsubscribe();
         }
@@ -198,6 +213,26 @@ const SettingsPopup = () => {
                             : defaultToggleTrackClass}`}
                     >
                         <div className={`w-[15px] h-[15px] rounded-full transition-transform duration-300 ease-spring ${toggleKnobClass} ${isUndetectable ? 'translate-x-[12px]' : 'translate-x-0'}`} />
+                    </button>
+                </div>
+
+                {/* Mouse Passthrough */}
+                <div className={`flex items-center justify-between px-3 py-2 rounded-lg transition-colors duration-200 group cursor-default ${itemHoverClass}`}>
+                    <div className="flex items-center gap-3">
+                        <PointerOff
+                            className={`w-4 h-4 transition-colors ${isMousePassthrough ? 'text-sky-500' : iconInactiveClass}`}
+                        />
+                        <span className={`text-[12px] font-medium transition-colors ${isMousePassthrough ? (isLightTheme ? 'text-slate-950' : 'text-white') : labelInactiveClass}`}>Mouse Passthrough</span>
+                    </div>
+                    <button
+                        onClick={() => {
+                            const newState = !isMousePassthrough;
+                            setIsMousePassthrough(newState);
+                            window.electronAPI?.setOverlayMousePassthrough(newState);
+                        }}
+                        className={`w-[30px] h-[18px] rounded-full p-[1.5px] transition-all duration-300 ease-spring active:scale-[0.92] ${isMousePassthrough ? 'bg-sky-500 shadow-[0_2px_10px_rgba(14,165,233,0.3)]' : defaultToggleTrackClass}`}
+                    >
+                        <div className={`w-[15px] h-[15px] rounded-full transition-transform duration-300 ease-spring ${toggleKnobClass} ${isMousePassthrough ? 'translate-x-[12px]' : 'translate-x-0'}`} />
                     </button>
                 </div>
 

--- a/src/components/ui/TopPill.tsx
+++ b/src/components/ui/TopPill.tsx
@@ -1,4 +1,4 @@
-import { ChevronUp, ChevronDown } from "lucide-react";
+import { ChevronUp, ChevronDown, PointerOff } from "lucide-react";
 import icon from "../icon.png";
 import type { OverlayAppearance } from "../../lib/overlayAppearance";
 
@@ -8,6 +8,7 @@ interface TopPillProps {
     onQuit: () => void;
     appearance: OverlayAppearance;
     onLogoClick?: () => void;
+    mousePassthroughEnabled?: boolean;
 }
 
 export default function TopPill({
@@ -16,6 +17,7 @@ export default function TopPill({
     onQuit,
     appearance,
     onLogoClick,
+    mousePassthroughEnabled = false,
 }: TopPillProps) {
     return (
         <div className="flex justify-center mt-2 select-none z-50">
@@ -81,6 +83,25 @@ export default function TopPill({
                     </span>
                     <span className="tracking-wide opacity-80 group-hover:opacity-100">{expanded ? "Hide" : "Show"}</span>
                 </button>
+
+                {mousePassthroughEnabled && (
+                    <div
+                        className="
+            flex items-center gap-1.5
+            px-3 py-1.5
+            rounded-full
+            text-[11px]
+            font-medium
+            border
+            overlay-chip-surface
+            overlay-text-primary
+          "
+                        style={appearance.chipStyle}
+                    >
+                        <PointerOff className="w-3.5 h-3.5 opacity-80" />
+                        <span className="tracking-wide opacity-90">Mouse Passthrough</span>
+                    </div>
+                )}
 
                 {/* STOP / QUIT BUTTON */}
                 <button

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -17,6 +17,7 @@ export interface ShortcutConfig {
     moveWindowRight: string[];
     // General
     toggleVisibility: string[];
+    toggleMousePassthrough: string[];
     processScreenshots: string[];
     resetCancel: string[];
     takeScreenshot: string[];
@@ -36,6 +37,7 @@ export const DEFAULT_SHORTCUTS: ShortcutConfig = {
     moveWindowLeft: ['⌘', '←'],
     moveWindowRight: ['⌘', '→'],
     toggleVisibility: ['⌘', 'B'],
+    toggleMousePassthrough: ['⌘', 'Shift', 'B'],
     processScreenshots: ['⌘', 'Enter'],
     resetCancel: ['⌘', 'R'],
     takeScreenshot: ['⌘', 'H'],
@@ -69,6 +71,7 @@ export const useShortcuts = () => {
                 else if (kb.id === 'window:move-right') newShortcuts.moveWindowRight = keys;
                 // General
                 else if (kb.id === 'general:toggle-visibility') newShortcuts.toggleVisibility = keys;
+                else if (kb.id === 'general:toggle-mouse-passthrough') newShortcuts.toggleMousePassthrough = keys;
                 else if (kb.id === 'general:process-screenshots') newShortcuts.processScreenshots = keys;
                 else if (kb.id === 'general:reset-cancel') newShortcuts.resetCancel = keys;
                 else if (kb.id === 'general:take-screenshot') newShortcuts.takeScreenshot = keys;
@@ -123,6 +126,7 @@ export const useShortcuts = () => {
         else if (actionId === 'moveWindowRight') backendId = 'window:move-right';
         // General
         else if (actionId === 'toggleVisibility') backendId = 'general:toggle-visibility';
+        else if (actionId === 'toggleMousePassthrough') backendId = 'general:toggle-mouse-passthrough';
         else if (actionId === 'processScreenshots') backendId = 'general:process-screenshots';
         else if (actionId === 'resetCancel') backendId = 'general:reset-cancel';
         else if (actionId === 'takeScreenshot') backendId = 'general:take-screenshot';

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -49,6 +49,9 @@ export interface ElectronAPI {
   openExternal: (url: string) => Promise<void>
   setUndetectable: (state: boolean) => Promise<{ success: boolean; error?: string }>
   getUndetectable: () => Promise<boolean>
+  setOverlayMousePassthrough: (enabled: boolean) => Promise<{ success: boolean }>
+  toggleOverlayMousePassthrough: () => Promise<{ success: boolean; enabled: boolean }>
+  getOverlayMousePassthrough: () => Promise<boolean>
   setDisguise: (mode: 'terminal' | 'settings' | 'activity' | 'none') => Promise<{ success: boolean; error?: string }>
   getDisguise: () => Promise<'none' | 'terminal' | 'settings' | 'activity'>
   onDisguiseChanged: (callback: (mode: 'terminal' | 'settings' | 'activity' | 'none') => void) => () => void
@@ -189,6 +192,7 @@ export interface ElectronAPI {
   flushDatabase: () => Promise<{ success: boolean }>;
 
   onUndetectableChanged: (callback: (state: boolean) => void) => () => void;
+  onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => () => void;
   onGroqFastTextChanged: (callback: (enabled: boolean) => void) => () => void;
   onModelChanged: (callback: (modelId: string) => void) => () => void;
 


### PR DESCRIPTION
## Summary
- add an overlay mouse passthrough mode so the meeting overlay stays visible without intercepting hover, clicks, or focus from the underlying app
- add main-process, IPC, preload, and renderer plumbing plus a global `CommandOrControl+Shift+B` shortcut for toggling passthrough
- add synced Mouse Passthrough controls to the full settings overlay, compact settings popup, and overlay chrome indicator

Fixes #

## Type of Change
- ✨ New Feature

## Testing & Environment
- [x] Manual test performed on: **macOS**
- [x] `npm run build:electron`
- [x] `npm run build`

Manual verification was completed by the user on macOS, including click-through and focus behavior.

## Visuals (Optional)
- None