### PR TITLE
fix: sync KeybindManager mode with WindowHelper mode switches

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -1,6 +1,7 @@
 
 import { BrowserWindow, screen, app, Menu } from "electron"
 import { AppState } from "./main"
+import { KeybindManager } from "./services/KeybindManager"
 import path from "node:path"
 
 const isEnvDev = process.env.NODE_ENV === "development"
@@ -459,6 +460,7 @@ export class WindowHelper {
   public switchToOverlay(inactive?: boolean): void {
     console.log(`[WindowHelper] Switching to OVERLAY (inactive: ${!!inactive})`);
     this.currentWindowMode = 'overlay';
+    KeybindManager.getInstance().setMode('overlay');
 
     // Tell the overlay renderer to expand to full size (e.g. after being minimised)
     this.overlayWindow?.webContents.send('ensure-expanded');
@@ -512,6 +514,7 @@ export class WindowHelper {
   public switchToLauncher(inactive?: boolean): void {
     console.log(`[WindowHelper] Switching to LAUNCHER (inactive: ${!!inactive})`);
     this.currentWindowMode = 'launcher';
+    KeybindManager.getInstance().setMode('launcher');
 
     // Show Launcher FIRST
     if (this.launcherWindow && !this.launcherWindow.isDestroyed()) {

--- a/electron/services/KeybindManager.ts
+++ b/electron/services/KeybindManager.ts
@@ -61,7 +61,6 @@ export class KeybindManager {
         if (actionId === 'general:toggle-visibility') return true;
         if (actionId === 'general:toggle-mouse-passthrough') return true;
         if (actionId.startsWith('window:move-')) return true;
-        
         return false;
     }
 


### PR DESCRIPTION
## Problem

"Capture Screen & Ask AI" (Ctrl+Shift+Enter) didn't work on any platform. No errors, no console output — the hotkey was simply never registered.

## Root Cause

`WindowHelper` and `KeybindManager` tracked window mode (`launcher`/`overlay`) independently without syncing.

- `WindowHelper.switchToOverlay()` set `currentWindowMode = 'overlay'` but never told `KeybindManager`
- `KeybindManager` stayed in `launcher` mode forever
- `shouldRegister()` blocks all shortcuts except `toggle-visibility`, `toggle-mouse-passthrough`, and `window:move-*` in launcher mode
- Screenshot/chat shortcuts were never registered as global hotkeys

## Fix

Added `KeybindManager.setMode()` calls in `WindowHelper` mode switchers:

- `switchToOverlay()` → `KeybindManager.getInstance().setMode('overlay')` — registers all shortcuts
- `switchToLauncher()` → `KeybindManager.getInstance().setMode('launcher')` — registers only base shortcuts

## Files Changed

- `electron/WindowHelper.ts` — import `KeybindManager`, call `setMode()` in `switchToOverlay` / `switchToLauncher`
- `electron/services/KeybindManager.ts` — removed extra whitespace line (no logic change)

## Testing

1. Launch app, enter overlay
2. Press Ctrl+Shift+Enter — should capture screen and send to AI
3. Exit to launcher mode — Ctrl+Shift+Enter should stop working (only toggle-visibility and window moves remain active)