### PR TITLE
fix: Google STT invalid_grant when app launched from Spotlight

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2309,10 +2309,16 @@ async function initializeApp() {
   sendAnonymousInstallPing();
 
   // Load stored Google Service Account path (for Speech-to-Text)
-  const storedServiceAccountPath = CredentialsManager.getInstance().getGoogleServiceAccountPath();
+  // Fall back to GOOGLE_APPLICATION_CREDENTIALS env var (set in terminal but not Spotlight)
+  const storedServiceAccountPath = CredentialsManager.getInstance().getGoogleServiceAccountPath()
+    || process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (storedServiceAccountPath) {
     console.log("[Init] Loading stored Google Service Account path");
     appState.updateGoogleCredentials(storedServiceAccountPath);
+    // Persist env-var path so Spotlight launches also work going forward
+    if (!CredentialsManager.getInstance().getGoogleServiceAccountPath()) {
+      CredentialsManager.getInstance().setGoogleServiceAccountPath(storedServiceAccountPath);
+    }
   }
 
   console.log("App is ready")


### PR DESCRIPTION
## Issue

When launching the app from **Spotlight** (or any macOS GUI launcher), Google STT fails immediately with:

```
Error: 400 undefined: Getting metadata from plugin failed with error: invalid_grant
```

The app works correctly when launched from the **terminal**.

## Root Cause

macOS GUI apps launched via Spotlight do **not** inherit shell environment variables. There are **two different credential files** in play:

- **Terminal launch**: inherits `$GOOGLE_APPLICATION_CREDENTIALS` from the shell → points to a **valid** credentials file → STT works
- **Spotlight launch**: no env var inherited → app falls back to the path stored in `CredentialsManager` (`googleServiceAccountPath`) → that stored file is **expired/revoked** → `invalid_grant` error

The startup code only loaded from `CredentialsManager` and never fell back to the env var, so the valid credentials used in the terminal were never picked up by the packaged app.

Confirmed via `~/Documents/natively_debug.log` which showed repeated `invalid_grant` errors only when launched outside the terminal.

## Fix

In `electron/main.ts` at startup, fall back to `process.env.GOOGLE_APPLICATION_CREDENTIALS` if `CredentialsManager` has no stored path:

```ts
const storedServiceAccountPath = CredentialsManager.getInstance().getGoogleServiceAccountPath()
  || process.env.GOOGLE_APPLICATION_CREDENTIALS;
```

Also auto-persist the env-var path into `CredentialsManager` so subsequent Spotlight launches use the valid file going forward — a one-time self-heal.

## Test Plan

- [ ] Launch app from terminal with `$GOOGLE_APPLICATION_CREDENTIALS` set, confirm path is saved to CredentialsManager
- [ ] Launch app from Spotlight (no env var) — confirm Google STT connects successfully using the persisted path
- [ ] Verify no regression when a valid path is already stored in CredentialsManager

