### PR TITLE
fix(overlay): preserve overlay position across hide/show

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -45,6 +45,19 @@ export class WindowHelper {
     this.appState = appState
   }
 
+  private getDisplayWorkArea(bounds?: Electron.Rectangle): Electron.Rectangle {
+    if (bounds) {
+      return screen.getDisplayMatching(bounds).workArea
+    }
+    if (this.overlayBounds) {
+      return screen.getDisplayMatching(this.overlayBounds).workArea
+    }
+    if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
+      return screen.getDisplayMatching(this.overlayWindow.getBounds()).workArea
+    }
+    return screen.getPrimaryDisplay().workArea
+  }
+
   public setContentProtection(enable: boolean): void {
     this.contentProtection = enable
     this.applyContentProtection(enable)
@@ -92,16 +105,16 @@ export class WindowHelper {
     console.log('[WindowHelper] setOverlayDimensions:', width, height);
 
     const [currentX, currentY] = this.overlayWindow.getPosition()
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const workArea = primaryDisplay.workAreaSize
+    const currentBounds = this.overlayWindow.getBounds()
+    const workArea = this.getDisplayWorkArea(currentBounds)
     const maxAllowedWidth = Math.floor(workArea.width * 0.9)
     const maxAllowedHeight = Math.floor(workArea.height * 0.9)
     const newWidth = Math.min(Math.max(width, 300), maxAllowedWidth) // min 300, max 90%
     const newHeight = Math.min(Math.max(height, 1), maxAllowedHeight) // min 1, max 90%
-    const maxX = workArea.width - newWidth
-    const maxY = workArea.height - newHeight
-    const newX = Math.min(Math.max(currentX, 0), maxX)
-    const newY = Math.min(Math.max(currentY, 0), maxY)
+    const maxX = workArea.x + workArea.width - newWidth
+    const maxY = workArea.y + workArea.height - newHeight
+    const newX = Math.min(Math.max(currentX, workArea.x), maxX)
+    const newY = Math.min(Math.max(currentY, workArea.y), maxY)
 
     this.overlayWindow.setContentSize(newWidth, newHeight)
     this.overlayWindow.setPosition(newX, newY)
@@ -510,19 +523,28 @@ export class WindowHelper {
 
     // Show Overlay FIRST
     if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
-      const primaryDisplay = screen.getPrimaryDisplay()
-      const workArea = primaryDisplay.workArea;
       const currentBounds = this.overlayWindow.getBounds();
-      const targetBounds = this.overlayBounds
+      const savedBounds = this.overlayBounds
         ? {
             ...this.overlayBounds,
             height: Math.max(this.overlayBounds.height, 216)
+          }
+        : null;
+      const workArea = this.getDisplayWorkArea(savedBounds ?? currentBounds);
+      const maxAllowedWidth = Math.floor(workArea.width * 0.9);
+      const maxAllowedHeight = Math.floor(workArea.height * 0.9);
+      const targetBounds = savedBounds
+        ? {
+            x: Math.min(Math.max(savedBounds.x, workArea.x), workArea.x + workArea.width - Math.min(savedBounds.width, maxAllowedWidth)),
+            y: Math.min(Math.max(savedBounds.y, workArea.y), workArea.y + workArea.height - Math.min(savedBounds.height, maxAllowedHeight)),
+            width: Math.min(savedBounds.width, maxAllowedWidth),
+            height: Math.min(savedBounds.height, maxAllowedHeight)
           }
         : {
             x: Math.floor(workArea.x + (workArea.width - 600) / 2),
             y: Math.floor(workArea.y + (workArea.height - 600) / 2),
             width: 600,
-            height: Math.max(currentBounds.height, 216)
+            height: Math.max(Math.min(currentBounds.height, maxAllowedHeight), 216)
           };
 
       this.overlayWindow.setBounds(targetBounds);


### PR DESCRIPTION
## Summary

Fixes the overlay window resetting to its default centered position after being hidden and shown again.

The root cause was that `switchToOverlay()` always re-centered the overlay instead of restoring the user’s last chosen position. This change adds dedicated overlay bounds tracking and reuses those bounds on subsequent overlay shows, while preserving centered placement for the first overlay display.

Fixes [#144](https://github.com/evinjohnn/natively-cluely-ai-assistant/issues/144)

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test performed on: macOS 26.4(Apple Silicon)
- [x] `npm run build`

Manual verification:
1. Launch the app
2. Switch to overlay mode
3. Move the overlay to a non-default position using both keyboard and mouse pointer
4. Hide the overlay
5. Show the overlay again
6. Confirm it reappears in the same position
7. Repeat hide/show multiple times to confirm it remains stable

## Visuals (Optional)

https://github.com/user-attachments/assets/4144c0a3-7bcf-4878-bc6f-a965b0ec63fb